### PR TITLE
bugfix and better handling of AP crash

### DIFF
--- a/esp32_fw/data/www/index.html
+++ b/esp32_fw/data/www/index.html
@@ -52,8 +52,9 @@
 
 			<div class="actionbox">
 				<div>
+					<div>Currently active tags:</div>
+					<div class="rebootbtn"><span id="rebootbutton">reboot AP</span></div>
 					<div class="editbtn"><a href="/edit" target="littlefs" class="filebutton">edit littleFS</a></div>
-					Currently active tags:<br>
 				</div>
 			</div>
 

--- a/esp32_fw/data/www/main.css
+++ b/esp32_fw/data/www/main.css
@@ -52,28 +52,32 @@ label {
 
 .actionbox>div:first-child {
 	padding: 10px;
-		background-color: white;
-		margin: 5px;
+	background-color: white;
+	margin: 5px;
 }
 
-.actionbox p {
-	padding: 5px;
+.actionbox>div:first-child>div:first-child {
+	flex-grow: 2;
 }
 
-.actionbox .columns {
+.actionbox>div {
 	display:flex;
-	flex-wrap: wrap;
+	gap: 20px;
 }
 
-.filebutton {
-	padding:2px 5px;
+#rebootbutton {
+	padding: 2px 5px;
 	background-color: #cccccc;
 	text-decoration: none;
 	color: black;
+	cursor: pointer;
 }
 
-.editbtn {
-	float:right;
+.filebutton {
+	padding: 2px 5px;
+	background-color: #cccccc;
+	text-decoration: none;
+	color: black;
 }
 
 .columns div {

--- a/esp32_fw/data/www/main.js
+++ b/esp32_fw/data/www/main.js
@@ -259,7 +259,28 @@ $('#cfgsave').onclick = function () {
 }
 
 $('#cfgdelete').onclick = function () {
-	let mac = $('#cfgmac').dataset.mac;
+	let formData = new FormData();
+	formData.append("mac", $('#cfgmac').dataset.mac);
+	fetch("/delete_cfg", {
+		method: "POST",
+		body: formData
+	})
+		.then(response => response.text())
+		.then(data => {
+			var div = $('#tag' + $('#cfgmac').dataset.mac);
+			div.remove();
+			showMessage(data);
+		})
+		.catch(error => showMessage('Error: ' + error));
+	$('#configbox').style.display = 'none';
+}
+
+$('#rebootbutton').onclick = function () {
+	showMessage("rebooting AP....",true);
+	fetch("/reboot", {
+		method: "POST"
+	});
+	socket.close();
 }
 
 function contentselected() {

--- a/esp32_fw/include/newproto.h
+++ b/esp32_fw/include/newproto.h
@@ -10,3 +10,4 @@ extern void processJoinNetwork(struct espJoinNetwork* xjn);
 extern void processXferComplete(struct espXferComplete* xfc);
 extern void processXferTimeout(struct espXferComplete* xfc);
 extern void processDataReq(struct espAvailDataReq* adr);
+void refreshAllPending();

--- a/esp32_fw/include/pendingdata.h
+++ b/esp32_fw/include/pendingdata.h
@@ -8,9 +8,7 @@
 class pendingdata {
    public:
     String filename;
-    //uint8_t dst[8];
     uint64_t ver;
-    String md5;
     uint32_t timeout;
     uint8_t datatimeout;
     uint8_t* data = nullptr;

--- a/esp32_fw/include/tag_db.h
+++ b/esp32_fw/include/tag_db.h
@@ -43,6 +43,7 @@ class tagRecord {
 
 extern std::vector<tagRecord*> tagDB;
 String tagDBtoJson(uint8_t mac[6] = nullptr, uint8_t startPos = 0);
+bool deleteRecord(uint8_t mac[6]);
 void fillNode(JsonObject &tag, tagRecord* &taginfo);
 void saveDB(String filename);
 void loadDB(String filename);

--- a/esp32_fw/src/contentmanager.cpp
+++ b/esp32_fw/src/contentmanager.cpp
@@ -200,7 +200,7 @@ void initSprite(TFT_eSprite &spr, int w, int h) {
     spr.setColorDepth(8);
     spr.createSprite(w, h);
     if (spr.getPointer() == nullptr) {
-        wsErr("Failed to create sprite in drawNumber");
+        wsErr("Failed to create sprite");
     }
     spr.fillSprite(TFT_WHITE);
 }

--- a/esp32_fw/src/main.cpp
+++ b/esp32_fw/src/main.cpp
@@ -44,10 +44,10 @@ void setup() {
     init_web();
     loadDB("/current/tagDB.json");
 
-    xTaskCreate(timeTask, "timed tasks", 10000, NULL, 2, NULL);
     xTaskCreate(zbsRxTask, "zbsRX Process", 10000, NULL, 2, NULL);
     xTaskCreate(garbageCollection, "pending-data cleanup", 5000, NULL, 1, NULL);
     xTaskCreate(webSocketSendProcess, "ws", 5000, NULL,configMAX_PRIORITIES-10, NULL);
+    xTaskCreate(timeTask, "timed tasks", 10000, NULL, 2, NULL);
 }
 
 void loop() {

--- a/esp32_fw/src/serial.cpp
+++ b/esp32_fw/src/serial.cpp
@@ -251,6 +251,8 @@ void zbsRxTask(void* parameter) {
                 Serial.println("I wasn't able to connect to a ZBS tag, trying to reboot the tag.");
                 Serial.println("If this problem persists, please check wiring and definitions in the settings.h file, and presence of the right firmware");
                 simplePowerOn();
+                wsErr("The AP tag crashed. Restarting tag, regenerating all pending info.");
+                refreshAllPending();
             }
         }
         


### PR DESCRIPTION
bugfix: crash on startup when websockets were not yet properly initialised
robustness: if AP crashes, write to log, and restore all pending images to AP.
also: rebootbutton (saves DB, reboots esp, reconnects websocket, so nothing lost)
also: deleting tag (delete icon) now works
